### PR TITLE
[donion_v1.2.3]

### DIFF
--- a/src/SentryFactory.cpp
+++ b/src/SentryFactory.cpp
@@ -524,18 +524,17 @@ uint8_t SentryFactory::UartSetBaudrate(sentry_baudrate_e baud) {
   return err;
 }
 
-uint8_t SentryFactory::Snapshot(
-    bool send2sd, bool send2uart, bool send2usb,
-    bool send2wifi, bool shot_from_screen,
-    sentry_snapshot_image_e image_type) {
+uint8_t SentryFactory::Snapshot(uint8_t image_dest, sentry_snapshot_src_e image_src, 
+    sentry_snapshot_type_e image_type) {
   sentry_err_t err;
   sentry_snapshot_conf_t reg;
-
-  reg.send2sd = send2sd;
-  reg.send2uart = send2uart;
-  reg.send2usb = send2usb;
-  reg.send2wifi = send2wifi;
-  reg.source = shot_from_screen;
+  
+  if (mode_ != kSerialMode) {
+    return SENTRY_FAIL;
+  }
+  reg.value &= 0xF0;
+  reg.value |= image_dest;
+  reg.source = image_src;
   reg.image_type = image_type;
 
   err = stream_->Set(kRegSnapshot, reg.value);
@@ -543,48 +542,12 @@ uint8_t SentryFactory::Snapshot(
   return err;
 }
 
-// WiFi functions
-uint8_t SentryFactory::WiFiConfig(bool enable, sentry_wifi_baudrate_e baudrate) {
-  sentry_err_t err;
-  sentry_wifi_conf_t reg;
-
-  err = stream_->Get(kRegWiFiConfig, &reg.value);
-  if (err) return err;
-  reg.enable = enable;
-  if (enable) {
-    reg.baudrate = baudrate;
-  }
-  stream_->Set(kRegWiFiConfig, reg.value);
-
-  return err;
+uint8_t SentryFactory::ImageReceive(sentry_image_frame_t *image, int timeout) {
+  TODO：图片接收函数，在此函数内new一个数组用于存放图片数据，并将地址导出
 }
 
-uint8_t SentryFactory::WiFiSend2Uart(bool enable) {
-  sentry_err_t err;
-  sentry_wifi_conf_t reg;
-
-  err = stream_->Get(kRegWiFiConfig, &reg.value);
-  if (err) return err;
-  if (reg.send2uart != enable) {
-    reg.send2uart = enable;
-    err = stream_->Set(kRegWiFiConfig, reg.value);
-  }
-
-  return err;
-}
-
-uint8_t SentryFactory::WiFiSend2Usb(bool enable) {
-  sentry_err_t err;
-  sentry_wifi_conf_t reg;
-
-  err = stream_->Get(kRegWiFiConfig, &reg.value);
-  if (err) return err;
-  if (reg.send2usb != enable) {
-    reg.send2usb = enable;
-    err = stream_->Set(kRegWiFiConfig, reg.value);
-  }
-
-  return err;
+uint8_t SentryFactory::ImageDestroy(sentry_image_frame_t *image) {
+  TODO：图片释放函数，在此函数释放所new的数组
 }
 
 // Screen functions

--- a/src/SentryFactory.cpp
+++ b/src/SentryFactory.cpp
@@ -524,8 +524,9 @@ uint8_t SentryFactory::UartSetBaudrate(sentry_baudrate_e baud) {
   return err;
 }
 
-uint8_t SentryFactory::Snapshot(uint8_t image_dest, sentry_snapshot_src_e image_src, 
-    sentry_snapshot_type_e image_type) {
+uint8_t SentryFactory::Snapshot(uint8_t image_dest, 
+                                sentry_snapshot_src_e image_src, 
+                                sentry_snapshot_type_e image_type) {
   sentry_err_t err;
   sentry_snapshot_conf_t reg;
   
@@ -540,14 +541,6 @@ uint8_t SentryFactory::Snapshot(uint8_t image_dest, sentry_snapshot_src_e image_
   err = stream_->Set(kRegSnapshot, reg.value);
 
   return err;
-}
-
-uint8_t SentryFactory::ImageReceive(sentry_image_frame_t *image, int timeout) {
-  TODO：图片接收函数，在此函数内new一个数组用于存放图片数据，并将地址导出
-}
-
-uint8_t SentryFactory::ImageDestroy(sentry_image_frame_t *image) {
-  TODO：图片释放函数，在此函数释放所new的数组
 }
 
 // Screen functions

--- a/src/SentryFactory.h
+++ b/src/SentryFactory.h
@@ -218,46 +218,34 @@ class SentryFactory {
   virtual uint8_t UartSetBaudrate(sentry_baudrate_e);
 
   /**
-   * @brief Take a snapshot from camera/screen to SD card/UART/USB/WIFI.
-   * @param send2sd Send snapshot to SD card
-   * @param send2uart Send snapshot to UART
-   * @param send2usb Send snapshot to USB
-   * @param send2wifi Send snapshot to WiFi
-   * @param shot_from_screen true: take a snapshot from screen
-   *                         false: take a snapshot from camera
-   * @param image_type Snapshot save image format
+   * @brief Start to take a snapshot from camera/screen to SD card/UART/USB/WIFI. Receive Image data by ImageReceive functions
+   * @param image_dest Send image to SD or UART or USB or WIFI ports
+   * @param image_src Image capture from camera or screen
+   * @param image_type Snapshot image format
    * @retval SENTRY_OK:  success
    *         other:  error
    */
-  virtual uint8_t Snapshot(
-      bool send2sd = true, bool send2uart = false, bool send2usb = false,
-      bool send2wifi = false, bool shot_from_screen = false,
-      sentry_snapshot_image_e image_type = kSnapshotImageJPEG);
+  virtual uint8_t Snapshot(uint8_t image_dest, sentry_snapshot_src_e image_src = kSnapshotImageSrcCamera, 
+    sentry_snapshot_type_e image_type = kSnapshotImageJPEG);
 
-  // WiFi functions
   /**
-   * @brief WiFi config.
-   * @param enable Enable WiFi
-   * @param baudrate WiFi baudrate
-   * @retval SENTRY_OK:  success
+   * @brief Receive an image frame
+   * 
+   * @param image image handle
+   * @param timeout max wait time in ms, default is 5000ms
+   * @return SENTRY_OK:  success
    *         other:  error
    */
-  virtual uint8_t WiFiConfig(
-      bool enable, sentry_wifi_baudrate_e baudrate = kWiFiBaud1152000);
+  virtual uint8_t SentryFactory::ImageReceive(sentry_image_frame_t *image, int timeout = 5000);
+    
   /**
-   * @brief WiFi message send to UART port.
-   * @param enable Send to UART or not
-   * @retval SENTRY_OK:  success
-   *         other:  error
+   * @brief Destroy the temp buffer of an image
+   * 
+   * @param image image handle
+   * @return SENTRY_OK:  success
+   *         other:  error 
    */
-  virtual uint8_t WiFiSend2Uart(bool enable);
-  /**
-   * @brief WiFi message send to UART port.
-   * @param enable Send to USB or not
-   * @retval SENTRY_OK:  success
-   *         other:  error
-   */
-  virtual uint8_t WiFiSend2Usb(bool enable);
+  virtual uint8_t SentryFactory::ImageDestroy(sentry_image_frame_t *image);
 
   // Screen functions
   /**

--- a/src/SentryFactory.h
+++ b/src/SentryFactory.h
@@ -218,34 +218,17 @@ class SentryFactory {
   virtual uint8_t UartSetBaudrate(sentry_baudrate_e);
 
   /**
-   * @brief Start to take a snapshot from camera/screen to SD card/UART/USB/WIFI. Receive Image data by ImageReceive functions
+   * @brief Start to take a snapshot from camera/screen to SD card/UART/USB/WIFI. 
+   *        Receive Image data by ImageReceive functions
    * @param image_dest Send image to SD or UART or USB or WIFI ports
    * @param image_src Image capture from camera or screen
    * @param image_type Snapshot image format
    * @retval SENTRY_OK:  success
    *         other:  error
    */
-  virtual uint8_t Snapshot(uint8_t image_dest, sentry_snapshot_src_e image_src = kSnapshotImageSrcCamera, 
-    sentry_snapshot_type_e image_type = kSnapshotImageJPEG);
-
-  /**
-   * @brief Receive an image frame
-   * 
-   * @param image image handle
-   * @param timeout max wait time in ms, default is 5000ms
-   * @return SENTRY_OK:  success
-   *         other:  error
-   */
-  virtual uint8_t SentryFactory::ImageReceive(sentry_image_frame_t *image, int timeout = 5000);
-    
-  /**
-   * @brief Destroy the temp buffer of an image
-   * 
-   * @param image image handle
-   * @return SENTRY_OK:  success
-   *         other:  error 
-   */
-  virtual uint8_t SentryFactory::ImageDestroy(sentry_image_frame_t *image);
+  virtual uint8_t Snapshot(uint8_t image_dest, 
+                           sentry_snapshot_src_e image_src = kSnapshotImageSrcCamera, 
+                           sentry_snapshot_type_e image_type = kSnapshotImageJPEG);
 
   // Screen functions
   /**

--- a/src/sentry_type.h
+++ b/src/sentry_type.h
@@ -187,12 +187,30 @@ typedef enum {
   kPercentageCoordinate = 1,
 } sentry_coordinate_type_e;
 typedef enum {
-  kSnapshotImageGray = 1,
-  kSnapshotImageRGB565 = 2,
-  kSnapshotImageRGB888 = 3,
-  kSnapshotImageJPEG = 4,
-  kSnapshotImagePNG = 5,
-} sentry_snapshot_image_e;
+  kSnapshot2SD = 1,
+  kSnapshot2Uart = 2,
+  kSnapshot2Usb = 4,
+  kSnapshot2Wifi = 8,
+} sentry_snapshot_dest_e;
+typedef enum {
+  kSnapshotFromCamera = 0,
+  kSnapshotFromScreen = 1,
+} sentry_snapshot_src_e;
+typedef enum {
+  kSnapshotTypeRGB565 = 2,
+  kSnapshotTypeJPEG = 4,
+  kSnapshotTypeJPEGBase64 = 5,
+} sentry_snapshot_type_e;
+
+typedef struct {
+  uint8_t start;
+  uint8_t type;
+  uint16_t width;
+  uint16_t height;
+  uint32_t size;
+  uint8_t **buf;
+} sentry_image_frame_t;
+
 /* register type */
 typedef union {
   struct {


### PR DESCRIPTION
在V1.2.3基础上做的更改
1.修改了snapshot函数的参数，详见
2.[需要]增加ImageReceive图像帧接收函数和ImageDestroy图像释放函数，这个只能用串口实现，不支持I2C，（本次PR不包含这两个函数的实现方式，需要大佬亲自添加）
3.snapshot函数调用方式见demo:examples/ScreenSnapshot.ino，针对ESP8266做了修改
4.去掉了WiFi相关的硬件设置函数，软件里用不到的功能